### PR TITLE
fix delay message replayer

### DIFF
--- a/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/MessageLogReplayer.java
+++ b/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/MessageLogReplayer.java
@@ -117,7 +117,6 @@ public class MessageLogReplayer implements Switchable {
                 if (LOG_LIMITER.tryAcquire()) {
                     LOGGER.info("replay message log failed,cursor < iterate,cursor:{},iterate:{}", cursor, iterate);
                 }
-                if ((iterate % PER_SEGMENT_FILE_SIZE) != 0) throw new RuntimeException("MessageReplayLessThanEx");
                 this.cursor.set(iterate);
             }
 

--- a/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/store/visitor/DelayMessageLogVisitor.java
+++ b/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/store/visitor/DelayMessageLogVisitor.java
@@ -104,7 +104,7 @@ public class DelayMessageLogVisitor implements LogVisitor<LogRecord> {
         // magic
         final int magic = buffer.getInt();
         if (!MagicCodeSupport.isValidMessageLogMagicCode(magic)) {
-//            visitedBufferSize.set(currentBuffer.getSize());
+            visitedBufferSize.set(currentBuffer.getSize());
             return Optional.of(EMPTY_LOG_RECORD);
         }
 


### PR DESCRIPTION
I found that the delay message replayer depend on that PER_SEGMENT_FILE_SIZE in LogSegment is equals to 1G,therwise there would be some accident.And i fix it.