### PR TITLE
Add unit tests for LongHashSet, ListUtils and CharsetUtils

### DIFF
--- a/qmq-common/src/test/java/qunar/tc/qmq/utils/CharsetUtilsTest.java
+++ b/qmq-common/src/test/java/qunar/tc/qmq/utils/CharsetUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Qunar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package qunar.tc.qmq.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CharsetUtilsTest {
+
+    @Test
+    public void testToUTF8Bytes() {
+        Assert.assertArrayEquals(new byte[0], CharsetUtils.toUTF8Bytes(""));
+        Assert.assertArrayEquals(new byte[0], CharsetUtils.toUTF8Bytes(null));
+        Assert.assertArrayEquals(new byte[]{102, 111, 111},
+                CharsetUtils.toUTF8Bytes("foo"));
+    }
+
+    @Test
+    public void testToUTF8String() {
+        Assert.assertEquals("", CharsetUtils.toUTF8String(null));
+        Assert.assertEquals("", CharsetUtils.toUTF8String(new byte[0]));
+        Assert.assertEquals("foo",
+                CharsetUtils.toUTF8String(new byte[]{102, 111, 111}));
+    }
+}

--- a/qmq-common/src/test/java/qunar/tc/qmq/utils/ListUtilsTest.java
+++ b/qmq-common/src/test/java/qunar/tc/qmq/utils/ListUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Qunar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package qunar.tc.qmq.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ListUtilsTest {
+
+    @Test
+    public void testContains() {
+        Assert.assertTrue(ListUtils.contains(new ArrayList<>(Arrays.asList(
+                new byte[0])), new byte[0]));
+        Assert.assertTrue(ListUtils.contains(new ArrayList<>(Arrays.asList(
+                new byte[]{1, 2, 3})), new byte[]{1, 2, 3}));
+
+        Assert.assertFalse(ListUtils.contains(new ArrayList<>(Arrays.asList(
+                new byte[]{1, 2, 3})), new byte[0]));
+        Assert.assertFalse(ListUtils.contains(new ArrayList<>(Arrays.asList(
+                new byte[]{1, 2, 3})), new byte[]{4, 5, 6}));
+        Assert.assertFalse(ListUtils.contains(new ArrayList<>(Arrays.asList(
+                new byte[]{1}, new byte[]{2}, new byte[]{3})),
+                new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    public void testContainsAll() {
+        Assert.assertTrue(ListUtils.containsAll(
+                new ArrayList<>(Arrays.asList(new byte[0])),
+                new ArrayList<>(Arrays.asList(new byte[0]))));
+        Assert.assertTrue(ListUtils.containsAll(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2}))));
+
+        Assert.assertFalse(ListUtils.containsAll(
+                new ArrayList<>(Arrays.asList(new byte[0])),
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2}))));
+        Assert.assertFalse(ListUtils.containsAll(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{2, 3, 4}))));
+        Assert.assertFalse(ListUtils.containsAll(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{4, 5, 6}))));
+    }
+
+    @Test
+    public void testIntersection() {
+        Assert.assertTrue(ListUtils.intersection(
+                new ArrayList<>(Arrays.asList(new byte[0])),
+                new ArrayList<>(Arrays.asList(new byte[0]))));
+        Assert.assertTrue(ListUtils.intersection(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2}))));
+
+        Assert.assertFalse(ListUtils.intersection(
+                new ArrayList<>(Arrays.asList(new byte[0])),
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2}))));
+        Assert.assertFalse(ListUtils.intersection(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{2, 3, 4}))));
+        Assert.assertFalse(ListUtils.intersection(
+                new ArrayList<>(Arrays.asList(new byte[]{1, 2})),
+                new ArrayList<>(Arrays.asList(new byte[]{4, 5, 6}))));
+    }
+}

--- a/qmq-delay-server/pom.xml
+++ b/qmq-delay-server/pom.xml
@@ -38,6 +38,16 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.diffblue</groupId>
+            <artifactId>deeptestutils</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/qmq-delay-server/src/test/java/qunar/tc/qmq/delay/base/LongHashSetTest.java
+++ b/qmq-delay-server/src/test/java/qunar/tc/qmq/delay/base/LongHashSetTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Qunar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package qunar.tc.qmq.delay.base;
+
+import com.diffblue.deeptestutils.Reflector;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LongHashSetTest {
+
+    @Test
+    public void testSet1() {
+        Assert.assertTrue(new LongHashSet(2).set(-1));
+    }
+
+    @Test
+    public void testSet2() throws InvocationTargetException {
+        LongHashSet longHashSet = (LongHashSet) Reflector
+                .getInstance("qunar.tc.qmq.delay.base.LongHashSet");
+        Reflector.setField(longHashSet, "values", new long[]{1L, -1L});
+        Assert.assertTrue(longHashSet.set(2L));
+    }
+
+    @Test
+    public void testContains() {
+        Assert.assertFalse(new LongHashSet(2).contains(-1));
+        Assert.assertFalse(new LongHashSet(2).contains(2));
+    }
+
+    @Test
+    public void testContains2() throws InvocationTargetException {
+        LongHashSet longHashSet = (LongHashSet) Reflector
+                .getInstance("qunar.tc.qmq.delay.base.LongHashSet");
+        Reflector.setField(longHashSet, "values", new long[]{1L, -1L});
+
+        Assert.assertFalse(longHashSet.contains(1L));
+        Assert.assertFalse(longHashSet.contains(2L));
+    }
+
+    @Test
+    public void testContains3() throws InvocationTargetException {
+        LongHashSet objectUnderTest = (LongHashSet) Reflector
+                .getInstance("qunar.tc.qmq.delay.base.LongHashSet");
+        Reflector.setField(objectUnderTest, "values", new long[]{0L});
+
+        Assert.assertTrue(objectUnderTest.contains(0L));
+    }
+
+    @Test
+    public void testSize() {
+        LongHashSet longHashSet1 = new LongHashSet(0);
+        longHashSet1.set(2L);
+        Assert.assertEquals(1, longHashSet1.size());
+
+        LongHashSet longHashSet2 = new LongHashSet(0);
+        longHashSet2.set(-1L);
+        Assert.assertEquals(1, longHashSet2.size());
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `qunar.tc.qmq.delay.base.LongHashSet` , `qunar.tc.qmq.utils.ListUtils` and `qunar.tc.qmq.utils.CharsetUtils` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.