### PR TITLE
change LogRecord.class to MessageLogRecord.class to solve the problem…

### DIFF
--- a/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/DefaultDelayLogFacade.java
+++ b/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/DefaultDelayLogFacade.java
@@ -28,6 +28,7 @@ import qunar.tc.qmq.delay.store.IterateOffsetManager;
 import qunar.tc.qmq.delay.store.log.*;
 import qunar.tc.qmq.delay.store.model.AppendLogResult;
 import qunar.tc.qmq.delay.store.model.LogRecord;
+import qunar.tc.qmq.delay.store.model.MessageLogRecord;
 import qunar.tc.qmq.delay.store.model.RawMessageExtend;
 import qunar.tc.qmq.delay.store.model.ScheduleSetRecord;
 import qunar.tc.qmq.delay.wheel.WheelLoadCursor;
@@ -62,7 +63,7 @@ public class DefaultDelayLogFacade implements DelayLogFacade {
         this.dispatchLog = new DispatchLog(config);
         this.offsetManager = new IterateOffsetManager(config.getCheckpointStorePath(), scheduleLog::flush);
         FixedExecOrderEventBus bus = new FixedExecOrderEventBus();
-        bus.subscribe(LogRecord.class, e -> {
+        bus.subscribe(MessageLogRecord.class, e -> {
             AppendLogResult<ScheduleIndex> result = appendScheduleLog(e);
             int code = result.getCode();
             if (MessageProducerCode.SUCCESS != code) {
@@ -71,7 +72,7 @@ public class DefaultDelayLogFacade implements DelayLogFacade {
             }
             func.apply(result.getAdditional());
         });
-        bus.subscribe(LogRecord.class, e -> {
+        bus.subscribe(MessageLogRecord.class, e -> {
             long checkpoint = e.getStartWroteOffset() + e.getRecordSize();
             updateIterateOffset(checkpoint);
         });


### PR DESCRIPTION
Hi, guys, I found a problem, after you started delay server, you could see that messages could be written to message_log, but no messages were replayed to schedule_log. I checked the code and found that in LogIterateService#processLog(), then visitor.nextRecord(), readOneRecord(currentBuffer), then in DelayMessageLogVisitor#readOneRecord(SegmentBuffer segmentBuffer), at the last line you could see return LogVisitorRecord.data(new MessageLogRecord(header, recordBytes, wroteOffset, payloadSize, message)), the event.getClass() was **MessageLogRecord**.   

However, in DefaultDelayLogFacade#DefaultDelayLogFacade(final StoreConfiguration config, final Function<ScheduleIndex, Boolean> func), you guys subscribed LogRecord in 
`        bus.subscribe(LogRecord.class, e -> {
            AppendLogResult<ScheduleIndex> result = appendScheduleLog(e);
            int code = result.getCode();
            if (MessageProducerCode.SUCCESS != code) {
                LOGGER.error("appendMessageLog schedule log error,log:{} {},code:{}", e.getSubject(), e.getMessageId(), code);
                throw new AppendException("appendScheduleLogError");
            }
            func.apply(result.getAdditional());
        });
        bus.subscribe(Record.class, e -> {
            long checkpoint = e.getStartWroteOffset() + e.getRecordSize();
            updateIterateOffset(checkpoint);
        });`

After I fixed the bug and restarted the delay server, it could run correctly.

Please have a review and approve it, thanks.