### PR TITLE
fix h2 KeyHolder

### DIFF
--- a/qmq-client/src/main/java/qunar/tc/qmq/producer/tx/spring/DefaultMessageStore.java
+++ b/qmq-client/src/main/java/qunar/tc/qmq/producer/tx/spring/DefaultMessageStore.java
@@ -83,7 +83,8 @@ public class DefaultMessageStore implements MessageStore {
         platform.update(this.insertStatementFactory.newPreparedStatementCreator(new Object[] {json, new Timestamp(System.currentTimeMillis())}), holder);
 
         message.setRouteKey(routerSelector.getRouteKey(platform.getDataSource()));
-        return holder.getKey().longValue();
+
+        return holder.getKeys().size() > 1 ? (Long)holder.getKeys().get("id") : holder.getKey().longValue();
     }
 
     @Override


### PR DESCRIPTION
修复 h2 或者 PostgreSQL数据源在做测试的时候会抛出

The getKey method should only be used when a single key is returned 异常