### PR TITLE
DelayQueue监控日志优化-时间轮和BatchExecutor重试逻辑优化

### DIFF
--- a/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/monitor/QMon.java
+++ b/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/monitor/QMon.java
@@ -127,4 +127,28 @@ public class QMon {
     public static void processTime(String subject, long time) {
         Metrics.timer("processTime", SUBJECT_ARRAY, new String[]{subject}).update(time, TimeUnit.MILLISECONDS);
     }
+
+    public static void sendBatchExecutorAddFailed(String subject) {
+        countInc("sendBatchExecutorAddFailed", subject);
+    }
+
+    public static void hashedWheelTimerExpireError() {
+        Metrics.counter("hashed_wheel_timer_expire_error", EMPTY, EMPTY).inc();
+    }
+
+    public static void sendBatchExecutorAddFailedRetryFailed(String subject) {
+        countInc("sendBatchExecutorAddFailedRetryFailed", subject);
+    }
+
+    public static void addWheelFailed(String subject) {
+        countInc("addWheelFailed", subject);
+    }
+
+    public static void sendProcessorFailed() {
+        Metrics.counter("sendProcessorFailed", EMPTY, EMPTY).inc();
+    }
+
+    public static void sendProcessorPartlyFailed() {
+        Metrics.counter("sendProcessorPartlyFailed", EMPTY, EMPTY).inc();
+    }
 }

--- a/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/startup/ServerWrapper.java
+++ b/qmq-delay-server/src/main/java/qunar/tc/qmq/delay/startup/ServerWrapper.java
@@ -76,19 +76,19 @@ public class ServerWrapper implements Disposable {
     private DynamicConfig config;
     private DefaultStoreConfiguration storeConfig;
 
-	public void start(boolean autoOnline) {
-		init();
-		register();
-		startServer();
-		sync();
-		if (autoOnline)
-			online();
-	}
+    public void start(boolean autoOnline) {
+        init();
+        register();
+        startServer();
+        sync();
+        if (autoOnline)
+            online();
+    }
 
-	public void online() {
-		BrokerConfig.markAsWritable();
-		brokerRegisterService.healthSwitch(true);
-	}
+    public void online() {
+        BrokerConfig.markAsWritable();
+        brokerRegisterService.healthSwitch(true);
+    }
 
     private void init() {
         this.config = DynamicConfigLoader.load("delay.properties");
@@ -122,7 +122,6 @@ public class ServerWrapper implements Disposable {
             wheelTickManager.addWHeel(index);
             return true;
         }
-
         return false;
     }
 

--- a/qmq-store/src/main/java/qunar/tc/qmq/store/PullLogManager.java
+++ b/qmq-store/src/main/java/qunar/tc/qmq/store/PullLogManager.java
@@ -17,6 +17,7 @@
 package qunar.tc.qmq.store;
 
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +130,11 @@ public class PullLogManager implements AutoCloseable {
     public void flush() {
         final long start = System.currentTimeMillis();
         try {
-            for (final PullLog log : logs.values()) {
+            /**
+             * 报java.util.ConcurrentModificationException，需要copy
+             */
+            Collection<PullLog> pullLogs = ImmutableList.copyOf(logs.values());
+            for (final PullLog log : pullLogs) {
                 log.flush();
             }
         } finally {
@@ -171,7 +176,8 @@ public class PullLogManager implements AutoCloseable {
 
     @Override
     public void close() {
-        for (final PullLog log : logs.values()) {
+        Collection<PullLog> pullLogs = ImmutableList.copyOf(logs.values());
+        for (final PullLog log : pullLogs) {
             log.close();
         }
     }


### PR DESCRIPTION
1. 完善监控和错误日志打印
2. pullLog遍历的时候，需要copy
3. batchExecutor队列满了，优化重试逻辑，重试前随机等待
4. Wheel里的队列满了，catch异常并进行固定等待重试
5. Wheel里expire逻辑抛Exception或者Error需要catch住